### PR TITLE
[codex] harden extract validation and document invoice workflow fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ print(api_key)
 
 - For invoice MVP integration issues (auth mismatch, parser edge cases, API scope alignment), see:
   - `docs/solutions/integration-issues/invoice-mvp-auth-and-parser-alignment-20260211.md`
+- For `/extract` 500 errors caused by zero-valued LLM product rows, see:
+  - `docs/solutions/runtime-errors/zero-valued-llm-product-rows-caused-extract-500-20260211.md`
 
 ## Testing
 

--- a/docs/brainstorms/2026-02-11-extract-openai-cache-by-file-hash-brainstorm.md
+++ b/docs/brainstorms/2026-02-11-extract-openai-cache-by-file-hash-brainstorm.md
@@ -1,0 +1,33 @@
+---
+date: 2026-02-11
+topic: extract-openai-cache-by-file-hash
+---
+
+# Extract OpenAI Cache by File Hash
+
+## What We're Building
+Add a cache for `POST /extract` so repeated uploads of the exact same PDF bytes do not call OpenAI again. The endpoint should return the same extracted `InvoiceData` payload from cache.
+
+The goal is lower cost, lower latency, and more stable repeated testing for the same invoice while keeping current API contract unchanged.
+
+## Why This Approach
+We considered three cache scopes: in-memory process cache, file-based disk cache, and shared Redis cache.
+
+Recommendation was in-memory process cache for MVP (YAGNI): smallest change surface, no extra infra, no schema migrations, and immediate value for local/dev/single-instance use.
+
+For cache key strategy, we considered exact file hash, normalized text-grid hash, and extracted invoice identity. We selected exact PDF-byte hash (`sha256`) as safest and deterministic for MVP.
+
+## Key Decisions
+- Cache scope: in-memory per backend process. Rationale: fastest delivery, no operational dependencies.
+- Cache key: exact uploaded PDF bytes hash (`sha256`). Rationale: deterministic, minimal false positives.
+- Behavior: cache hit must bypass OpenAI call and return previous extraction payload unchanged.
+- API contract: no response shape changes required for MVP.
+
+## Open Questions
+- TTL policy: no expiration vs finite TTL (for example 24h).
+- Memory cap/eviction: unbounded dict vs bounded LRU.
+- Optional observability: whether to expose hit/miss metric or debug header.
+- Multi-instance production behavior: accept per-instance misses for now, or plan later Redis upgrade.
+
+## Next Steps
+-> `/workflows:plan` for implementation details

--- a/docs/plans/2026-02-11-feat-extract-openai-cache-by-file-hash-plan.md
+++ b/docs/plans/2026-02-11-feat-extract-openai-cache-by-file-hash-plan.md
@@ -1,0 +1,169 @@
+---
+title: "feat: Extract OpenAI cache by file hash"
+type: "feat"
+date: "2026-02-11"
+source_brainstorm: "docs/brainstorms/2026-02-11-extract-openai-cache-by-file-hash-brainstorm.md"
+---
+
+# feat: Extract OpenAI cache by file hash
+
+## Overview
+
+Add an in-memory cache for `POST /extract` so re-uploading the exact same PDF bytes returns the previous extraction result without calling OpenAI again.
+
+Cache key will be `sha256` of raw uploaded PDF bytes. Scope is per-process memory (single instance).
+
+## Problem Statement / Motivation
+
+Current extraction flow always performs full processing and LLM call:
+- Save upload
+- Extract text grid
+- Call LLM
+- Validate
+- Return payload
+
+For repeated uploads of the same invoice, this increases:
+- latency
+- OpenAI cost
+- failure surface (timeouts/rate limits)
+
+The team already aligned on MVP scope in brainstorm: deterministic exact-file matching with no infra dependencies.
+
+## Local Research Summary
+
+### Internal references
+- `POST /extract` request flow: `src/invproc/api.py:178`
+- LLM call entrypoint: `src/invproc/api.py:225`
+- Existing request hashing pattern (idempotency): `src/invproc/import_service.py:194`
+- Config singleton usage: `src/invproc/config.py:254`
+- API tests for extract auth/behavior: `tests/test_api.py:48`
+
+### Institutional learnings applied
+- Keep request-safe state and avoid brittle globals:
+  `docs/solutions/runtime-errors/global-state-thread-safety-race-conditions.md`
+- Blocking operations in async route should stay in threadpool:
+  `docs/solutions/performance-issues/blocking-io-async-prevents-concurrency.md`
+- Global middleware/cache-like state must be reset in tests:
+  `docs/solutions/runtime-errors/llm-malformed-product-rows-500-and-test-limiter-flakes-20260210.md`
+
+## Research Decision
+
+External research skipped.
+
+Reason: this is a low-risk local optimization with clear existing repo patterns (hashing + FastAPI endpoint orchestration + in-memory test reset practices).
+
+## SpecFlow Analysis
+
+### Primary flow: cache miss
+1. Client uploads PDF to `POST /extract`.
+2. Backend computes file hash from uploaded bytes.
+3. Cache miss -> run normal extraction pipeline.
+4. Backend stores validated response payload under hash.
+5. Backend returns extraction response.
+
+### Primary flow: cache hit
+1. Client uploads same PDF bytes.
+2. Backend computes same file hash.
+3. Cache hit -> return cached payload.
+4. LLM call is skipped.
+
+### Edge cases
+- Different filename, same bytes -> same cache key (hit expected).
+- Same semantic invoice but different bytes/metadata -> cache miss (expected for MVP exact-match).
+- Very high unique-file churn -> memory growth risk.
+- Multi-instance deployment -> cache only per instance.
+
+## Proposed Solution
+
+### Design
+- Add a small in-memory extraction cache module/state.
+- Key: `sha256(pdf_bytes)`.
+- Value: serialized `InvoiceData` payload (JSON-compatible dict).
+- Endpoint behavior remains identical to clients.
+
+### API behavior
+- No contract change required.
+- Optional debug response header may be added later (`X-Extract-Cache: hit|miss`) if needed.
+
+### Scope boundaries
+- In scope: `/extract` cache only.
+- Out of scope: Redis/shared cache, dedupe across instances, cache invalidation APIs.
+
+## Technical Approach
+
+### Files to update
+- `src/invproc/api.py`
+  - Compute hash of uploaded file bytes for cache key.
+  - Read/write in-memory cache in extract flow.
+  - Keep existing error mapping behavior.
+- `src/invproc/config.py`
+  - Optional flags for cache enablement/size (if needed in MVP).
+- `tests/test_api.py`
+  - Add cache hit/miss behavior tests using mocked LLM call count.
+- `tests/test_error_paths.py`
+  - Ensure cache state does not leak between tests.
+
+### Implementation notes
+- Keep PDF upload size enforcement unchanged.
+- Avoid adding mutable request state outside controlled cache structure.
+- Use lock-safe access if cache may be touched concurrently.
+- Store a copy/serialized payload to avoid accidental mutation by callers.
+
+## Acceptance Criteria
+
+### Functional
+- [ ] First upload of a PDF hash performs full extraction and caches result.
+- [ ] Second upload of identical PDF bytes returns same payload without LLM call.
+- [ ] Different file bytes still execute normal extraction path.
+- [ ] Endpoint response schema remains unchanged.
+
+### Non-functional
+- [ ] No regression in auth, rate limiting, upload-size enforcement.
+- [ ] Concurrent requests do not corrupt cache state.
+- [ ] Tests deterministic and isolated (cache reset between tests).
+
+### Testing
+- [ ] Unit/API test for miss then hit sequence.
+- [ ] Test that same bytes with different filename still hit.
+- [ ] Test that changed bytes miss.
+- [ ] Full suite remains green.
+
+## Success Metrics
+
+- Reduced repeated `/extract` latency for identical files.
+- Reduced OpenAI calls for repeated uploads in local/single-instance workflows.
+- No new 5xx regressions introduced by cache.
+
+## Dependencies & Risks
+
+### Dependencies
+- None external for MVP in-memory cache.
+
+### Risks
+- Memory growth from unbounded unique uploads.
+- Cache effectiveness limited in multi-instance deployments.
+- Hidden coupling if cache object is globally mutable without protection.
+
+### Mitigations
+- Add bounded size (LRU) or explicit max entries soon after MVP.
+- Document per-instance behavior clearly.
+- Reset cache in test fixtures.
+
+## Rollout / Follow-ups
+
+### MVP now
+- In-memory exact-file hash cache.
+
+### Later (if needed)
+- Configurable TTL/LRU bounds.
+- Shared Redis cache for multi-instance environments.
+- Lightweight observability (hit/miss counters or debug header).
+
+## References & Research
+
+- Brainstorm: `docs/brainstorms/2026-02-11-extract-openai-cache-by-file-hash-brainstorm.md`
+- Endpoint flow: `src/invproc/api.py:178`
+- Idempotent hashing pattern: `src/invproc/import_service.py:194`
+- Thread-safety learning: `docs/solutions/runtime-errors/global-state-thread-safety-race-conditions.md`
+- Async blocking guidance: `docs/solutions/performance-issues/blocking-io-async-prevents-concurrency.md`
+- Test state reset learning: `docs/solutions/runtime-errors/llm-malformed-product-rows-500-and-test-limiter-flakes-20260210.md`

--- a/docs/solutions/runtime-errors/zero-valued-llm-product-rows-caused-extract-500-20260211.md
+++ b/docs/solutions/runtime-errors/zero-valued-llm-product-rows-caused-extract-500-20260211.md
@@ -1,0 +1,98 @@
+---
+module: System
+date: 2026-02-11
+problem_type: runtime_error
+component: extraction_pipeline
+symptoms:
+  - "POST /extract returned 500 Internal Server Error with Pydantic ValidationError for products.<index>.quantity/unit_price"
+  - "LLM output occasionally contained product rows with quantity=0.0 and unit_price=0.0"
+root_cause: normalization_gap
+resolution_type: code_fix
+severity: high
+tags: [llm-output, pydantic, fastapi, extraction, validation]
+related:
+  - docs/solutions/runtime-errors/llm-malformed-product-rows-500-and-test-limiter-flakes-20260210.md
+  - tests/test_error_paths.py
+---
+
+# Troubleshooting: Zero-Valued LLM Product Rows Caused `/extract` 500
+
+## Problem
+
+Invoice extraction failed with `500` even though malformed rows were already being filtered in normalization. The failing payload included a row with `quantity=0.0` and `unit_price=0.0`, which then failed strict `Product` model validation (`gt=0`).
+
+## Symptoms
+
+Response body from failing API call:
+
+```json
+{
+  "detail": "Processing failed: 2 validation errors for InvoiceData\nproducts.42.quantity ... input_value=0.0 ...\nproducts.42.unit_price ... input_value=0.0"
+}
+```
+
+Observed behavior:
+- `/extract` returned `500`.
+- Frontend logged generic HTTP failure without clear user-actionable outcome.
+
+## Root Cause
+
+`LLMExtractor._normalize_invoice_payload()` filtered `None` values but did not treat non-positive numeric values as malformed.
+
+This allowed zero-valued rows to pass normalization and crash later during Pydantic model construction:
+- `Product.quantity` requires `> 0`
+- `Product.unit_price` requires `> 0`
+
+## Solution
+
+Extended malformed-row filtering in normalization to reject non-positive numeric values:
+
+- Drop rows when:
+  - `quantity <= 0`
+  - `unit_price <= 0`
+  - `total_price < 0`
+- Keep resilient behavior:
+  - if at least one row remains valid, continue extraction
+  - if all rows are malformed, raise integrity error
+
+Code references:
+- `src/invproc/llm_extractor.py`
+- `tests/test_error_paths.py`
+
+## Why This Works
+
+- Prevents invalid rows from reaching strict Pydantic model validation.
+- Preserves robust extraction for mixed-quality LLM output.
+- Keeps failure explicit when output is entirely unusable.
+
+## Verification
+
+Targeted tests:
+
+```bash
+python3 -m pytest -q \
+  tests/test_error_paths.py::test_llm_filters_zero_quantity_and_unit_price_rows \
+  tests/test_error_paths.py::test_llm_filters_malformed_product_rows \
+  tests/test_error_paths.py::test_llm_raises_if_all_rows_malformed
+```
+
+Full suite:
+
+```bash
+python3 -m pytest -q
+```
+
+Result at time of fix:
+- `76 passed`
+
+## Prevention
+
+1. Normalize against model constraints, not only nullability.
+2. Add regression tests for boundary numerics (`0`, negative, NaN/inf where relevant).
+3. Keep parser resilience explicit: partial malformed rows can be dropped, fully malformed outputs must fail fast.
+4. When extraction resilience behavior changes, update API troubleshooting docs for frontend teams.
+
+## Related
+
+- Prior related incident and handling strategy:
+  `docs/solutions/runtime-errors/llm-malformed-product-rows-500-and-test-limiter-flakes-20260210.md`

--- a/docs/solutions/workflow-issues/stale-frontend-branch-masked-pricing-fixes-development-workflow-20260211.md
+++ b/docs/solutions/workflow-issues/stale-frontend-branch-masked-pricing-fixes-development-workflow-20260211.md
@@ -1,0 +1,77 @@
+---
+module: Development Workflow
+date: 2026-02-11
+problem_type: workflow_issue
+component: development_workflow
+symptoms:
+  - "Pricing preview looked incorrect even after backend extraction fixes were merged"
+  - "UI still showed old labeling and transport interpretation despite recent implementation updates"
+  - "Debugging effort focused on backend regressions while issue source was stale frontend code"
+root_cause: missing_workflow_step
+resolution_type: workflow_improvement
+severity: medium
+tags: [frontend-backend-alignment, branch-sync, pricing-preview, workflow]
+related:
+  - docs/solutions/runtime-errors/zero-valued-llm-product-rows-caused-extract-500-20260211.md
+  - docs/solutions/integration-issues/invoice-mvp-auth-and-parser-alignment-20260211.md
+---
+
+# Troubleshooting: Stale Frontend Branch Masked Pricing Fixes
+
+## Problem
+
+Pricing behavior appeared wrong during invoice validation, even though backend extraction and validation fixes had already been applied. The observed mismatch came from testing with a frontend state that did not include latest UI and calculation updates.
+
+## Environment
+
+- Module: Development Workflow
+- Affected Component: Frontend/backend integration test loop
+- Date: 2026-02-11
+
+## Symptoms
+
+- Product rows still displayed legacy pricing semantics after backend fixes.
+- Team suspected transport allocation and VAT conversion logic was still broken in backend.
+- Repeated checks against backend responses showed correct API-side values while UI output remained inconsistent.
+
+## What Didn't Work
+
+**Attempted Solution 1:** Continue backend investigation for transport/VAT math.  
+- **Why it failed:** Backend payload and validation were already corrected; additional backend debugging did not change UI behavior.
+
+**Attempted Solution 2:** Re-run invoice imports without confirming branch parity first.  
+- **Why it failed:** Reprocessing invoices on stale frontend code reproduced the same visual mismatch, creating a false regression signal.
+
+## Solution
+
+Enforced branch parity before evaluating pricing behavior:
+
+1. Confirm active branch and commit in both repositories.
+2. Pull latest `origin/main` for frontend and backend before verification.
+3. Re-test using same invoice only after both sides are aligned.
+4. Treat UI output mismatch as frontend issue unless backend response payload is also wrong.
+
+Practical checks used:
+
+```bash
+git branch --show-current
+git fetch origin
+git pull --ff-only origin main
+git rev-parse --short HEAD
+```
+
+## Why This Works
+
+The root cause was process drift, not calculation logic. Without a mandatory "sync both repos first" step, the team compared new backend behavior against old frontend rendering logic. Aligning branches removed false negatives and restored trustworthy debugging signals.
+
+## Prevention
+
+- Add "sync frontend + backend to latest main" as a mandatory pre-check in invoice pricing QA.
+- Record both commit SHAs in bug reports before investigating pricing mismatches.
+- Compare raw API response and UI rendering side-by-side to identify the failing layer early.
+- Treat cross-repo parity as a gate before concluding regressions in pricing math.
+
+## Related Issues
+
+- See also: `docs/solutions/runtime-errors/zero-valued-llm-product-rows-caused-extract-500-20260211.md`
+- See also: `docs/solutions/integration-issues/invoice-mvp-auth-and-parser-alignment-20260211.md`

--- a/src/invproc/models.py
+++ b/src/invproc/models.py
@@ -13,7 +13,11 @@ class Product(BaseModel):
     name: str = Field(..., description="Product name")
     quantity: float = Field(..., gt=0, description="Quantity must be positive")
     unit_price: float = Field(..., gt=0, description="Unit price must be positive")
-    total_price: float = Field(..., ge=0, description="Total line price")
+    total_price: float = Field(
+        ...,
+        ge=0,
+        description="Total line price including VAT (Valoare incl.TVA)",
+    )
     confidence_score: float = Field(..., ge=0, le=1, description="Confidence 0-1")
     row_id: Optional[str] = Field(None, description="Stable row identifier for this extraction")
     weight_kg_candidate: Optional[float] = Field(

--- a/src/invproc/validator.py
+++ b/src/invproc/validator.py
@@ -96,8 +96,15 @@ class InvoiceValidator:
         if calculated_total == 0:
             return False, 100.0
 
-        discrepancy = abs(calculated_total - product.total_price)
-        discrepancy_pct = (discrepancy / calculated_total) * 100
+        # In many invoices, total_price is VAT-inclusive while unit_price is ex-VAT.
+        # Accept either ex-VAT or common VAT-inclusive totals (8% / 20%).
+        candidate_totals = (
+            calculated_total,
+            calculated_total * 1.08,
+            calculated_total * 1.20,
+        )
+        best_discrepancy = min(abs(candidate - product.total_price) for candidate in candidate_totals)
+        discrepancy_pct = (best_discrepancy / calculated_total) * 100
 
         is_valid = discrepancy_pct <= 5.0
         return is_valid, discrepancy_pct

--- a/tests/test_invoice_pricing.py
+++ b/tests/test_invoice_pricing.py
@@ -17,3 +17,18 @@ def test_compute_pricing_parity_values() -> None:
     assert pricing.price_50 == 1.9885
     assert pricing.price_70 == 2.2536
     assert pricing.price_100 == 2.6513
+
+
+def test_compute_pricing_uses_vat_inclusive_line_total() -> None:
+    """Use line total including VAT and ensure transport is added."""
+    pricing = compute_pricing(
+        line_total_lei=359.70,
+        quantity=3.0,
+        weight_kg=0.5,
+        fx_lei_to_eur=19.5,
+        transport_rate_per_kg=1.5,
+    )
+
+    assert pricing.base_price_eur == 6.1487
+    assert pricing.transport_eur == 0.75
+    assert pricing.price_70 == 11.7278

--- a/tests/test_llm_prompt_guidance.py
+++ b/tests/test_llm_prompt_guidance.py
@@ -1,0 +1,14 @@
+"""Regression tests for extraction prompt guidance."""
+
+from invproc.config import InvoiceConfig
+from invproc.llm_extractor import LLMExtractor
+
+
+def test_prompt_is_vat_aware_for_total_column() -> None:
+    extractor = LLMExtractor(InvoiceConfig(mock=True))
+    prompt = extractor._get_system_prompt()
+
+    assert "total_price` MUST come from" in prompt
+    assert "Valoare incl.TVA" in prompt
+    assert "Never alter quantity or total_price just to make math match." in prompt
+    assert "Do not map quantity from \"Unit\" or \"Mod\"." in prompt


### PR DESCRIPTION
## Summary
This PR hardens invoice extraction against malformed/invalid LLM rows, improves VAT-aware pricing validation confidence, and documents two solved troubleshooting paths discovered during invoice pricing QA.

From a user perspective, this reduces extraction failures and lowers the risk of false diagnostics during pricing debugging.

## User Impact (Cause and Effect)
Before these changes:
- `/extract` could return `500` when LLM output contained product rows with non-positive numeric values (for example `quantity=0` or `unit_price=0`).
- Confidence scoring for candidate totals was less explicit around VAT-inclusive invoice behavior.
- Teams could lose time debugging backend pricing logic while actually testing stale frontend state.

After these changes:
- Invalid product rows are filtered at normalization time, so mixed-quality LLM output is still processable.
- Candidate confidence scoring is aligned to VAT-inclusive totals (base, +8%, +20%).
- Troubleshooting docs now include concrete workflow guardrails for cross-repo branch parity.

## Root Cause
1. Normalization gap: malformed-row filtering only rejected `None`-style values, not non-positive numeric values that violate strict `Product` constraints.
2. Validation clarity gap: confidence scoring logic needed explicit VAT-aware candidate handling in implementation/tests.
3. Workflow gap: cross-repo debugging happened without a mandatory “both repos on latest main/expected branch” pre-check.

## What Changed
### Extraction and validation
- Hardened product-row normalization and filtering in `src/invproc/llm_extractor.py`.
- Clarified VAT-inclusive semantics in `src/invproc/models.py`.
- Updated VAT-aware confidence behavior in `src/invproc/validator.py`.

### Tests
- Added and expanded regression coverage in:
  - `tests/test_error_paths.py`
  - `tests/test_invoice_pricing.py`
  - `tests/test_validator.py`
  - `tests/test_llm_prompt_guidance.py`

### Documentation
- Added troubleshooting solution doc for zero-valued row 500 failures:
  - `docs/solutions/runtime-errors/zero-valued-llm-product-rows-caused-extract-500-20260211.md`
- Added workflow troubleshooting doc for stale frontend branch masking pricing fixes:
  - `docs/solutions/workflow-issues/stale-frontend-branch-masked-pricing-fixes-development-workflow-20260211.md`
- Added brainstorming/plan docs for OpenAI extract cache exploration:
  - `docs/brainstorms/2026-02-11-extract-openai-cache-by-file-hash-brainstorm.md`
  - `docs/plans/2026-02-11-feat-extract-openai-cache-by-file-hash-plan.md`
- Updated troubleshooting references in `README.md`.

## Validation
Executed locally:

```bash
python3 -m pytest -q
```

Result:
- `76 passed in 6.18s`

## Notes
This PR focuses on robustness and troubleshooting quality. The hash-based extraction cache remains planned/documented and intentionally deferred from MVP implementation.
