### PR TITLE
[codex] add extract cache with observability and tests

### DIFF
--- a/docs/plans/2026-02-11-feat-openai-extraction-cache-file-hash-plan.md
+++ b/docs/plans/2026-02-11-feat-openai-extraction-cache-file-hash-plan.md
@@ -1,0 +1,185 @@
+---
+title: "feat: OpenAI Extraction Cache by File Hash"
+type: "feat"
+date: "2026-02-11"
+source: "docs/brainstorms/2026-02-11-extract-openai-cache-by-file-hash-brainstorm.md"
+---
+
+# feat: OpenAI Extraction Cache by File Hash
+
+## Overview
+
+Add a backend cache for `POST /extract` keyed by uploaded PDF content hash so repeated uploads of the same file can reuse a prior extraction result and skip new OpenAI calls.
+
+Primary goals:
+- Reduce OpenAI cost for duplicate files.
+- Improve response latency for repeated requests.
+- Preserve existing API contract (`InvoiceData`) and validation flow.
+
+## Problem Statement / Motivation
+
+`/extract` currently always runs full pipeline: save upload -> PDF processing -> OpenAI extraction -> validation -> row metadata.
+
+Current orchestration is in `src/invproc/api.py:193`. LLM call happens in `src/invproc/api.py:225` via `LLMExtractor.parse_with_llm` (`src/invproc/llm_extractor.py:31`). There is no extraction-result cache.
+
+For repeated uploads of the same invoice (manual retries, frontend re-uploads, QA runs), we pay the same OpenAI cost and latency each time.
+
+## Idea Refinement Input
+
+No matching brainstorm file was present at `docs/brainstorms/2026-02-11-extract-openai-cache-by-file-hash-brainstorm.md` in this worktree. Planning proceeded from the feature intent in the filename and current codebase patterns.
+
+## Local Research Summary
+
+### Internal References
+
+- `/extract` flow and error mapping: `src/invproc/api.py:178`
+- LLM call boundary: `src/invproc/llm_extractor.py:31`
+- Config singleton and validation style: `src/invproc/config.py:28`
+- Existing hash/idempotency pattern: `src/invproc/import_service.py:194`
+- Existing API test style and fixture reset patterns: `tests/test_api.py:14`
+
+### Institutional Learnings Applied
+
+- Keep blocking work out of event loop with `run_in_threadpool`: `docs/solutions/performance-issues/blocking-io-async-prevents-concurrency.md`
+- Avoid unsafe shared mutable globals for request logic: `docs/solutions/runtime-errors/global-state-thread-safety-race-conditions.md`
+- Reset shared state in tests to avoid flakiness (especially limiters/caches): `docs/solutions/runtime-errors/llm-malformed-product-rows-500-and-test-limiter-flakes-20260210.md`
+
+## External Research Decision
+
+External research included because this touches OpenAI API behavior and caching strategy.
+
+Key references:
+- OpenAI Prompt Caching overview: [OpenAI Prompt Caching](https://platform.openai.com/docs/guides/prompt-caching)
+- OpenAI API reference: [Responses API](https://platform.openai.com/docs/api-reference/responses)
+
+Decision: keep this feature as an application-level file hash cache. Do not rely on prompt caching alone, since prompt caching does not eliminate request execution and does not provide deterministic per-file replay semantics.
+
+## Proposed Solution
+
+Implement an in-memory extraction cache keyed by PDF content hash (`sha256`) and validated against relevant config dimensions.
+
+### Scope (MVP)
+
+- Cache key includes:
+  - `file_hash` (hash of uploaded bytes)
+  - extraction-affecting config snapshot (`model`, `temperature`, `max_tokens`, invoice parsing headers)
+- Cache value stores:
+  - validated `InvoiceData` response payload (`model_dump(mode="json")`)
+  - metadata (`created_at`, `hit_count`)
+- Cache location:
+  - process-local in-memory component (new module)
+- Endpoint behavior:
+  - On cache hit, return cached payload after model re-hydration.
+  - On cache miss, execute existing pipeline and persist response in cache.
+
+### Explicit Non-Goals (MVP)
+
+- Distributed/shared cache (Redis, DB) across workers.
+- Long-term persistence across process restarts.
+- Automatic invalidation based on model quality changes beyond key dimensions.
+
+## Technical Considerations
+
+- Concurrency/thread safety:
+  - Cache must be lock-protected, matching existing thread-safe patterns (`src/invproc/repositories/memory.py:11`).
+- Event loop safety:
+  - Hashing large files should not block async path excessively; keep heavy operations in threadpool where needed.
+- Memory limits:
+  - Add bounded size and TTL to avoid unbounded growth.
+- Correctness:
+  - Must never return stale payload for incompatible config/model values.
+
+## SpecFlow Analysis
+
+### Primary Flow
+
+1. Client uploads PDF to `POST /extract`.
+2. API streams to temp file and computes file hash.
+3. API checks extraction cache with key (`file_hash` + config signature).
+4. If hit: return cached `InvoiceData`.
+5. If miss: run extract -> LLM -> validate -> metadata enrichment.
+6. Store successful response in cache and return payload.
+
+### Edge Cases
+
+- Same file bytes, different `model` or `column_headers` config: must miss.
+- OpenAI timeout/error responses: must not cache failures.
+- Malformed LLM output (`422`): must not cache.
+- Rate limited (`429`) or auth failures (`401`): unaffected by cache.
+- Multi-worker deployment: per-process cache inconsistency is acceptable in MVP; document it.
+
+### Gaps Closed by Plan
+
+- No duplicate OpenAI calls for same file in one process.
+- Deterministic cache invalidation via key signature, not manual flush.
+
+## Implementation Plan
+
+### Phase 1: Cache primitive and config
+
+- [x] `src/invproc/config.py`: add cache settings (`extract_cache_enabled`, `extract_cache_ttl_sec`, `extract_cache_max_entries`).
+- [x] `src/invproc/extract_cache.py`: add thread-safe in-memory cache with TTL + max entries.
+- [x] `tests/test_config.py`: add config validation/default tests for new cache settings.
+
+### Phase 2: API integration
+
+- [x] `src/invproc/api.py`: add helper to compute `file_hash` (`sha256`) from uploaded temp file.
+- [x] `src/invproc/api.py`: build config signature helper for cache key.
+- [x] `src/invproc/api.py`: check cache before `pdf_processor.extract_content` and write cache on successful response.
+- [x] `src/invproc/api.py`: ensure exception paths do not populate cache.
+
+### Phase 3: Tests and observability
+
+- [x] `tests/test_api.py`: add hit/miss behavior tests (same file twice -> second call bypasses LLM mock invocation).
+- [x] `tests/test_api.py`: add tests proving config signature change forces miss.
+- [x] `tests/test_api.py`: add tests proving error responses are not cached.
+- [x] `src/invproc/api.py`: add low-noise logs/headers for diagnostics (e.g., cache hit/miss log line).
+
+## Acceptance Criteria
+
+- [x] Re-uploading identical PDF with same cache key dimensions returns same `InvoiceData` without new OpenAI call.
+- [x] Cache miss occurs when extraction-affecting config signature changes.
+- [x] `401`, `422`, `429`, `500`, `504` responses are never cached.
+- [x] Cache has bounded growth (TTL + max entries enforced).
+- [x] All existing API tests pass; new cache tests pass.
+
+## Success Metrics
+
+- Cache hit ratio for `/extract` duplicate-file traffic is measurable.
+- OpenAI request count decreases for duplicate-file workloads.
+- Median response time improves on repeated uploads.
+
+## Dependencies & Risks
+
+### Dependencies
+
+- Existing `POST /extract` flow in `src/invproc/api.py` remains source of truth.
+- Config management through singleton `get_config()` in `src/invproc/config.py:254`.
+
+### Risks
+
+- Process-local cache may have low hit rates under multi-worker deployment.
+- Memory pressure if cache bounds are misconfigured.
+- Incorrect cache key dimensions could serve stale/incorrect payloads.
+
+### Mitigations
+
+- Keep key signature explicit and versioned.
+- Use conservative defaults for TTL and max entries.
+- Add targeted tests for invalidation dimensions.
+
+## References & Research
+
+### Internal
+
+- `src/invproc/api.py:193`
+- `src/invproc/llm_extractor.py:31`
+- `src/invproc/import_service.py:194`
+- `docs/solutions/performance-issues/blocking-io-async-prevents-concurrency.md`
+- `docs/solutions/runtime-errors/global-state-thread-safety-race-conditions.md`
+- `docs/solutions/runtime-errors/llm-malformed-product-rows-500-and-test-limiter-flakes-20260210.md`
+
+### External
+
+- [OpenAI Prompt Caching](https://platform.openai.com/docs/guides/prompt-caching)
+- [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses)

--- a/docs/solutions/workflow-issues/extract-cache-verification-observability-and-coverage-20260211.md
+++ b/docs/solutions/workflow-issues/extract-cache-verification-observability-and-coverage-20260211.md
@@ -1,0 +1,102 @@
+---
+module: Invoice Processing API
+date: 2026-02-11
+problem_type: workflow_issue
+component: development_workflow
+symptoms:
+  - "Manual cache verification for POST /extract was ambiguous because runtime logs did not show cache hit/miss signals"
+  - "Timing-only checks were noisy and could not reliably prove cache behavior"
+  - "New cache primitive had no direct TTL/LRU unit tests, leaving eviction/expiry guarantees under-specified"
+root_cause: missing_workflow_step
+resolution_type: workflow_improvement
+severity: medium
+tags: [extract-cache, observability, testing, lru, ttl, fastapi]
+related:
+  - docs/plans/2026-02-11-feat-openai-extraction-cache-file-hash-plan.md
+  - todos/001-complete-p2-cache-observability-hit-miss-signals.md
+  - todos/002-complete-p2-extract-cache-ttl-lru-tests.md
+---
+
+# Troubleshooting: Extract Cache Verification Needed Explicit Signals and Invariant Tests
+
+## Problem
+
+After implementing file-hash caching for `POST /extract`, manual validation remained uncertain. Server logs did not reliably surface cache hit/miss status in common `uvicorn` runs, and timing-based checks alone were insufficient to prove behavior. In parallel, cache internals (TTL expiry and LRU eviction) were not directly tested.
+
+## Environment
+
+- Module: Invoice Processing API
+- Affected Component: `/extract` cache verification workflow and test coverage
+- Date: 2026-02-11
+
+## Symptoms
+
+- Two identical `/extract` calls returned `200`, but no clear runtime signal showed whether second call was a cache hit.
+- Teams relied on elapsed time as proxy, which is unstable with small files, local variance, and network jitter.
+- Review identified missing direct tests for `InMemoryExtractCache` TTL and LRU behavior.
+
+## What Didn't Work
+
+**Attempted Solution 1:** Validate cache solely by response timing.
+- **Why it failed:** Timing deltas are not deterministic and can mislead under variable runtime conditions.
+
+**Attempted Solution 2:** Depend on module logger messages for cache status.
+- **Why it failed:** Logger output was not consistently visible in runtime logs in the current launch path, creating an observability gap.
+
+## Solution
+
+Implemented two complementary fixes:
+
+1. **Deterministic runtime signal in API responses**
+- Added `X-Extract-Cache` response header on `/extract` when cache is enabled.
+  - `miss` for cache miss path
+  - `hit` for cache hit path
+- File: `src/invproc/api.py`
+
+2. **Direct unit tests for cache invariants**
+- Added dedicated tests for `InMemoryExtractCache`:
+  - basic hit/miss
+  - TTL expiry behavior
+  - LRU eviction behavior
+  - `configure()` capacity prune behavior
+- File: `tests/test_extract_cache.py`
+
+3. **Strengthened existing API tests**
+- Asserted `X-Extract-Cache` transitions (`miss` then `hit`) for identical requests.
+- Asserted miss after extraction-affecting config change.
+- File: `tests/test_api.py`
+
+## Why This Works
+
+- Header-based signaling makes cache behavior explicit and environment-independent for manual verification.
+- Invariant unit tests verify eviction/expiry guarantees directly instead of inferring them from endpoint behavior.
+- Combined API + unit coverage reduces false confidence and catches regressions at both integration and primitive levels.
+
+## Verification
+
+Commands used:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_extract_cache.py tests/test_api.py tests/test_config.py -q
+python3 -m ruff check src/invproc/api.py tests/test_api.py tests/test_extract_cache.py tests/test_config.py
+```
+
+Result at fix time:
+- `37 passed`
+- `All checks passed!`
+
+## Prevention
+
+- Treat cache behavior as a first-class contract with deterministic observability (`X-Extract-Cache`) for manual debugging.
+- Always add direct unit tests for new cache primitives (TTL, eviction, reconfiguration), not only endpoint-level tests.
+- Avoid using timing as primary correctness proof for cache behavior.
+- In PR reviews, require both:
+  - one integration test for hit/miss behavior
+  - one primitive-level test suite for cache invariants
+
+## Related Issues
+
+- Plan: `docs/plans/2026-02-11-feat-openai-extraction-cache-file-hash-plan.md`
+- Todo closure records:
+  - `todos/001-complete-p2-cache-observability-hit-miss-signals.md`
+  - `todos/002-complete-p2-extract-cache-ttl-lru-tests.md`

--- a/src/invproc/config.py
+++ b/src/invproc/config.py
@@ -182,6 +182,25 @@ class InvoiceConfig(BaseSettings):
         description="Transport surcharge in EUR per kilogram",
     )
 
+    extract_cache_enabled: bool = Field(
+        default=False,
+        description="Enable in-memory extraction cache for repeated identical PDFs",
+    )
+
+    extract_cache_ttl_sec: int = Field(
+        default=86400,
+        ge=1,
+        le=604800,
+        description="Extraction cache TTL in seconds",
+    )
+
+    extract_cache_max_entries: int = Field(
+        default=256,
+        ge=1,
+        le=10000,
+        description="Maximum number of cached extraction entries",
+    )
+
     def create_output_dirs(self) -> Path:
         """Ensure output directories exist."""
         self.output_dir.mkdir(parents=True, exist_ok=True)
@@ -239,6 +258,12 @@ class InvoiceConfig(BaseSettings):
 
         if self.openai_timeout_sec < 10 or self.openai_timeout_sec > 600:
             errors.append("OPENAI_TIMEOUT_SEC must be between 10 and 600")
+
+        if self.extract_cache_ttl_sec < 1:
+            errors.append("EXTRACT_CACHE_TTL_SEC must be >= 1")
+
+        if self.extract_cache_max_entries < 1:
+            errors.append("EXTRACT_CACHE_MAX_ENTRIES must be >= 1")
 
         # Raise error if any validation failed
         if errors:

--- a/src/invproc/extract_cache.py
+++ b/src/invproc/extract_cache.py
@@ -1,0 +1,90 @@
+"""In-memory cache for extracted invoice payloads."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ExtractCacheEntry:
+    """Cache payload metadata."""
+
+    payload: dict
+    expires_at: float
+    hit_count: int
+
+
+class InMemoryExtractCache:
+    """Thread-safe TTL + LRU cache for extract responses."""
+
+    def __init__(self, *, ttl_sec: int, max_entries: int) -> None:
+        self._lock = threading.Lock()
+        self._ttl_sec = ttl_sec
+        self._max_entries = max_entries
+        self._entries: OrderedDict[str, ExtractCacheEntry] = OrderedDict()
+
+    def configure(self, *, ttl_sec: int, max_entries: int) -> None:
+        """Apply runtime cache limits from config."""
+        with self._lock:
+            self._ttl_sec = ttl_sec
+            self._max_entries = max_entries
+            self._prune_expired_locked()
+            self._prune_capacity_locked()
+
+    def get(self, key: str) -> Optional[dict]:
+        """Return cached payload if present and not expired."""
+        now = time.time()
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+
+            if entry.expires_at <= now:
+                self._entries.pop(key, None)
+                return None
+
+            # Mark as recently used and update observability counter.
+            updated = ExtractCacheEntry(
+                payload=entry.payload,
+                expires_at=entry.expires_at,
+                hit_count=entry.hit_count + 1,
+            )
+            self._entries[key] = updated
+            self._entries.move_to_end(key)
+            return updated.payload
+
+    def set(self, key: str, payload: dict) -> None:
+        """Insert/update payload and enforce TTL/capacity bounds."""
+        now = time.time()
+        with self._lock:
+            self._prune_expired_locked(now=now)
+            self._entries[key] = ExtractCacheEntry(
+                payload=payload,
+                expires_at=now + self._ttl_sec,
+                hit_count=0,
+            )
+            self._entries.move_to_end(key)
+            self._prune_capacity_locked()
+
+    def reset(self) -> None:
+        """Clear cache state (used by tests)."""
+        with self._lock:
+            self._entries.clear()
+
+    def _prune_expired_locked(self, *, now: Optional[float] = None) -> None:
+        if now is None:
+            now = time.time()
+
+        expired_keys = [
+            key for key, entry in self._entries.items() if entry.expires_at <= now
+        ]
+        for key in expired_keys:
+            self._entries.pop(key, None)
+
+    def _prune_capacity_locked(self) -> None:
+        while len(self._entries) > self._max_entries:
+            self._entries.popitem(last=False)

--- a/tests/test_extract_cache.py
+++ b/tests/test_extract_cache.py
@@ -1,0 +1,58 @@
+"""Unit tests for in-memory extract cache behavior."""
+
+from invproc.extract_cache import InMemoryExtractCache
+
+
+def test_extract_cache_hit_and_miss() -> None:
+    """Basic set/get behavior returns payload for known keys."""
+    cache = InMemoryExtractCache(ttl_sec=60, max_entries=2)
+    payload = {"supplier": "A"}
+
+    assert cache.get("k1") is None
+    cache.set("k1", payload)
+    assert cache.get("k1") == payload
+
+
+def test_extract_cache_ttl_expiry(monkeypatch) -> None:
+    """Expired entries should return miss and be removed."""
+    now = [1000.0]
+
+    def fake_time() -> float:
+        return now[0]
+
+    monkeypatch.setattr("invproc.extract_cache.time.time", fake_time)
+
+    cache = InMemoryExtractCache(ttl_sec=10, max_entries=5)
+    cache.set("k1", {"supplier": "A"})
+    assert cache.get("k1") == {"supplier": "A"}
+
+    now[0] = 1011.0
+    assert cache.get("k1") is None
+
+
+def test_extract_cache_lru_eviction() -> None:
+    """Least recently used key should be evicted when capacity exceeded."""
+    cache = InMemoryExtractCache(ttl_sec=60, max_entries=2)
+    cache.set("k1", {"v": 1})
+    cache.set("k2", {"v": 2})
+    # Touch k1 so k2 becomes LRU.
+    assert cache.get("k1") == {"v": 1}
+    cache.set("k3", {"v": 3})
+
+    assert cache.get("k2") is None
+    assert cache.get("k1") == {"v": 1}
+    assert cache.get("k3") == {"v": 3}
+
+
+def test_extract_cache_configure_prunes_over_capacity() -> None:
+    """Reducing max_entries via configure should prune oldest entries."""
+    cache = InMemoryExtractCache(ttl_sec=60, max_entries=3)
+    cache.set("k1", {"v": 1})
+    cache.set("k2", {"v": 2})
+    cache.set("k3", {"v": 3})
+
+    cache.configure(ttl_sec=60, max_entries=1)
+
+    assert cache.get("k1") is None
+    assert cache.get("k2") is None
+    assert cache.get("k3") == {"v": 3}


### PR DESCRIPTION
## Summary

This PR adds an application-level extraction cache for `POST /extract`, keyed by the exact uploaded PDF byte hash plus an extraction config signature.

The change was driven by repeated uploads of the same invoice causing repeated LLM calls, which increased cost and latency without improving output quality. The cache now reuses prior validated `InvoiceData` payloads for identical inputs.

## User Impact

Before this change, users and QA repeatedly uploading the same PDF would always trigger a new extraction pipeline and OpenAI call.

After this change, repeated uploads of identical file bytes can return immediately from cache (when `EXTRACT_CACHE_ENABLED=true`), reducing repeat-call latency and API cost while preserving the same response contract.

## Root Cause

The `/extract` endpoint had no deduplication or replay mechanism for identical requests. Even exact duplicate files were reprocessed end-to-end.

Additionally, manual validation of cache behavior was hard because runtime hit/miss signals were not deterministic from server logs alone.

## What Changed

### 1) New cache primitive

- Added `InMemoryExtractCache` with thread-safe TTL + LRU behavior:
  - `src/invproc/extract_cache.py`

### 2) Cache configuration

- Added config fields:
  - `extract_cache_enabled` (default `false`)
  - `extract_cache_ttl_sec` (default `86400`)
  - `extract_cache_max_entries` (default `256`)
- File: `src/invproc/config.py`

### 3) `/extract` cache integration

- Upload streaming now computes `sha256` digest while writing temp file.
- Cache key: `file_hash + extraction config signature`.
- On cache hit: return cached `InvoiceData` and skip LLM call.
- On cache miss: run normal extraction and cache successful response payload.
- Added response header for deterministic observability:
  - `X-Extract-Cache: miss|hit`
- File: `src/invproc/api.py`

### 4) Test coverage

- Added API tests for cache behavior and invalidation:
  - hit skips second LLM call
  - config change forces miss
  - malformed-output (`422`) path not cached
- Added direct unit tests for cache invariants:
  - set/get hit
  - TTL expiry
  - LRU eviction
  - `configure()` capacity pruning
- Files:
  - `tests/test_api.py`
  - `tests/test_extract_cache.py`
  - `tests/test_config.py`

### 5) Knowledge capture

- Added implementation plan doc:
  - `docs/plans/2026-02-11-feat-openai-extraction-cache-file-hash-plan.md`
- Added solution doc for verification/coverage learnings:
  - `docs/solutions/workflow-issues/extract-cache-verification-observability-and-coverage-20260211.md`

## Validation

Executed locally:

- `PYTHONPATH=src python3 -m pytest tests/test_extract_cache.py tests/test_api.py tests/test_config.py -q`
  - Result: `37 passed`
- `python3 -m ruff check src/invproc/api.py src/invproc/config.py src/invproc/extract_cache.py tests/test_api.py tests/test_config.py tests/test_extract_cache.py`
  - Result: `All checks passed`

## Notes

- Cache is process-local for MVP and intentionally does not provide cross-instance sharing.
- Cache remains opt-in via configuration and defaults to disabled.
