### PR TITLE
[codex] Fix Render deploy missing supabase dependency

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -22,11 +22,12 @@ services:
       
       # Configure these in Render dashboard:
       # - OPENAI_API_KEY (required)
-      # - API_KEYS (required, comma-separated)
+      # - SUPABASE_URL (required)
+      # - SUPABASE_SERVICE_ROLE_KEY (required)
       # - ALLOWED_ORIGINS (optional, defaults to localhost domains + prod frontend)
 
       - key: ALLOWED_ORIGINS
-        value: http://localhost:3000,http://localhost:5173,https://lavio.vercel.app
+        value: http://localhost:5173,https://lavio.vercel.app
       
       - key: ALLOWED_CURRENCIES
         value: EUR,USD,MDL,RUB,RON

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
 python-multipart>=0.0.9
 slowapi>=0.1.9
+supabase>=2.3.0


### PR DESCRIPTION
## Summary
Fix Render deployment startup failure after Supabase JWT auth migration.

## Problem
Render deploys were failing at app startup with:
`ModuleNotFoundError: No module named 'supabase'`

The stack trace shows import failure in `src/invproc/auth.py` when loading `from supabase import Client, create_client`.

## Root Cause
The Docker build installs dependencies from `requirements.txt`, but `supabase` was only added to `pyproject.toml` optional extras (`.[api]`).

Render's Docker path (`pip install -r requirements.txt` + `pip install -e .`) therefore did not guarantee `supabase` was installed.

## Fix
- Added `supabase>=2.3.0` to `requirements.txt` so Docker/Render installs it.
- Updated `render.yaml` env comments to the new auth model:
  - `SUPABASE_URL`
  - `SUPABASE_SERVICE_ROLE_KEY`
- Aligned default `ALLOWED_ORIGINS` in `render.yaml` with current backend defaults.

## Validation
- Verified dependency resolves in local environment with `python -m pip install -r requirements.txt`.
- Confirmed this directly addresses the startup trace observed in Render logs.

## Impact
- Render container can import `invproc.auth` successfully.
- FastAPI server should start and pass `/health` check when required env vars are present.
