### PR TITLE
[codex] Refactor FastAPI resource lifecycles and test overrides

### DIFF
--- a/docs/plans/2026-02-26-refactor-fastapi-resource-lifecycle-plan.md
+++ b/docs/plans/2026-02-26-refactor-fastapi-resource-lifecycle-plan.md
@@ -1,0 +1,211 @@
+---
+title: refactor: Replace module-global API resources with FastAPI-managed lifecycles
+type: refactor
+date: 2026-02-26
+---
+
+# refactor: Replace module-global API resources with FastAPI-managed lifecycles
+
+## Overview
+
+Refactor FastAPI resource ownership so extraction cache, configuration lifecycle, and Supabase client lifecycle are provided through FastAPI dependencies and/or app startup state instead of module-level globals.
+
+This targets three current global-state patterns:
+
+- extraction cache in `src/invproc/api.py`
+- config singleton in `src/invproc/config.py`
+- Supabase client cache in `src/invproc/auth.py`
+
+The goal is to make runtime behavior explicit, improve test isolation, and let tests override dependencies without mutating imported module globals.
+
+## Problem Statement / Motivation
+
+The API still mixes dependency injection with module-global lifecycle state:
+
+- `extract_cache = InMemoryExtractCache(...)` is created at import time and shared across tests/requests (`src/invproc/api.py:46`)
+- `/extract` bypasses DI and calls `get_config()` directly inside the route (`src/invproc/api.py:181`)
+- `config.py` uses `_config_instance` singleton state (`src/invproc/config.py:276`)
+- `auth.py` caches Supabase client and credentials in `_client`, `_client_url`, `_client_key` (`src/invproc/auth.py:14`)
+
+Current tests work by resetting globals and reloading config:
+
+- `tests/test_api.py` imports `extract_cache` directly and resets it in an autouse fixture (`tests/test_api.py:9`, `tests/test_api.py:25`, `tests/test_api.py:37`)
+- `tests/test_api.py` and `tests/test_error_paths.py` call `reload_config()` to force config changes (`tests/test_api.py:10`, `tests/test_api.py:26`, `tests/test_api.py:38`, `tests/test_error_paths.py:15`, `tests/test_error_paths.py:26`, `tests/test_error_paths.py:31`)
+
+This creates hidden coupling between import order, environment mutation, and test execution, and it makes resource initialization behavior harder to reason about in multi-worker deployments.
+
+## Proposed Solution
+
+Use a FastAPI application factory (`create_app()`) with lifespan-initialized `app.state` resources and route dependencies.
+
+Proposed direction:
+
+- Introduce `create_app()` as the canonical API composition entrypoint (module-level `app = create_app()` can remain for runtime compatibility)
+- Introduce a dedicated app resource container (typed dataclass or lightweight class) attached to `app.state`
+- Initialize long-lived resources during app startup/lifespan:
+- `InvoiceConfig` (validated or unvalidated depending on use case)
+- `InMemoryExtractCache` built from config cache settings
+- Supabase auth provider/client object bound to the app's startup config (overrideable in tests)
+- Add dependency functions that read resources from `Request.app.state` instead of module globals
+- Update endpoints/auth dependencies to consume injected resources only
+- Add a canonical test app fixture/factory pattern that creates isolated app instances per test module/case as needed
+- Update tests to override these dependencies explicitly via `app.dependency_overrides` on the test app, instead of mutating module globals
+
+## Technical Considerations
+
+- FastAPI lifecycle model:
+  - Standardize on a lifespan function (preferred over mixed startup patterns) for resource initialization and predictable test setup/teardown.
+  - Avoid import-time side effects for cache/config/client creation.
+  - Keep a single composition path: `create_app()` builds middleware/routes and registers lifespan-managed resources.
+- Dependency design:
+  - `verify_supabase_jwt` currently depends on `get_config` (`src/invproc/auth.py:77`); after refactor, it should depend on an injected config provider and a Supabase client provider (directly or indirectly).
+  - `/extract` should inject config and extract cache dependencies rather than calling `get_config()` and using module `extract_cache` (`src/invproc/api.py:181`, `src/invproc/api.py:206`).
+  - Avoid “current config” key-matching caches in auth; app-scoped auth provider/client should be derived from startup config for the app instance.
+- Test ergonomics:
+  - Tests currently rely on `reload_config()` and imported globals for cache reset. Replace with fixture-owned config/cache instances and explicit dependency overrides to make each test independent.
+  - Define one canonical fixture pattern (for example `test_app` + `client`) so tests do not share a long-lived imported app when config/cache behavior is under test.
+  - Environment variable changes during a test should require either (a) a new app/client created after env mutation or (b) direct dependency overrides; do not rely on `reload_config()` to mutate a shared running app.
+  - Ensure `limiter.reset()` behavior remains available in tests (this can remain global if not in scope for this refactor).
+- Backward compatibility:
+  - CLI code and non-FastAPI modules may still use `get_config()` today. This refactor should avoid breaking CLI behavior while improving API-side lifecycle management.
+  - If `get_config()` remains for CLI, document that API paths no longer depend on the module singleton.
+- Concurrency/thread-safety:
+  - App-level cache is intentionally shared process-wide and should remain explicit, bounded, and resettable.
+  - Per-request processors (`PDFProcessor`, `LLMExtractor`, `InvoiceValidator`) already use DI and should remain per-request (`src/invproc/api.py:67`, `src/invproc/api.py:72`, `src/invproc/api.py:77`).
+
+## SpecFlow Analysis (Flows, Gaps, Edge Cases)
+
+Primary flow:
+
+- App startup initializes resource container on `app.state`
+- `create_app()` is the only constructor used by tests when resource behavior is under test
+- Request resolves config/cache/client via dependencies
+- `/extract` uses injected cache + config to execute pipeline
+- `verify_supabase_jwt` uses injected Supabase client provider and returns auth payload
+
+Key edge cases to cover:
+
+- Missing Supabase config should still return `500` auth configuration error (current behavior in `src/invproc/auth.py:37`)
+- Config changes in tests should not leak across test cases when a `TestClient` context closes and a new app/client is created
+- Tests that mutate env after client creation should not expect runtime app-state resources to refresh unless they rebuild the app/client
+- Cache enable/disable toggles should create the correct cache behavior and headers without requiring module reloads
+- Dependency override omissions should fail loudly (startup error or clear test fixture failure), not silently fall back to stale globals
+- Lifespan startup should run in tests that use `TestClient`; if tests bypass lifespan, fixtures must initialize app state explicitly
+
+## Acceptance Criteria
+
+- [x] `src/invproc/api.py` no longer defines a module-global extraction cache instance for request handling
+- [x] `/extract` route receives config and extract cache through FastAPI dependencies (no direct `get_config()` call inside handler)
+- [x] `src/invproc/config.py` no longer requires module-global `_config_instance` for API request paths (CLI compatibility can be preserved via separate path)
+- [x] `src/invproc/auth.py` no longer relies on module-global `_client`, `_client_url`, `_client_key` for API auth lifecycle
+- [x] `create_app()` is introduced as the canonical API composition entrypoint, with runtime compatibility preserved via exported module-level `app`
+- [x] FastAPI lifespan initializes and attaches required resources to `app.state`
+- [x] Tests use a canonical test app fixture/factory and override config/cache/auth-related dependencies explicitly using `app.dependency_overrides` on that test app instead of resetting imported globals
+- [x] API tests do not rely on `reload_config()` to mutate resources for an already-created `TestClient` instance
+- [x] Existing API auth and extract cache tests continue to validate cache hit/miss and auth error behavior
+- [x] Refactor preserves current endpoint behavior and status codes for `/health`, `/extract`, and `/invoice/preview-pricing`
+- [x] Quality gates pass:
+- [x] `python -m ruff check src/ tests/`
+- [x] `python -m mypy src/`
+- [x] `python -m pytest -q` (coverage fail-under remains 80%)
+
+## Success Metrics
+
+- Tests no longer need `reload_config()` for API dependency setup in endpoint tests
+- Endpoint tests no longer import and reset `extract_cache` from `invproc.api`
+- API resource initialization becomes traceable to startup/lifespan and dependency providers
+- Reduced hidden coupling between environment mutation and module import order
+- API resource behavior tests construct isolated app instances through `create_app()` rather than sharing a process-global app object
+
+## Dependencies & Risks
+
+Dependencies:
+
+- FastAPI app lifecycle support via lifespan/startup events
+- Stable dependency override points for tests (`app.dependency_overrides`)
+- A canonical `create_app()` path that tests and production import use consistently
+- Careful coordination between `invproc.api`, `invproc.auth`, and `invproc.config`
+
+Risks:
+
+- Breaking test assumptions that depend on current singleton/reload behavior
+- Accidentally changing auth error semantics while moving Supabase client creation behind providers
+- Lifespan not executing in some tests if fixture construction is inconsistent
+- Introducing duplicate resource initialization if both import-time and startup-time paths coexist temporarily
+- Scope creep from partial app-factory migration if routes/middleware setup is split between old and new composition paths
+
+Mitigations:
+
+- Refactor in small steps with temporary compatibility shims
+- Add/adjust focused tests for dependency override paths before removing globals
+- Centralize resource initialization in one function used by startup and tests
+- Make `create_app()` the sole place that assembles middleware/routes/resources to avoid dual initialization paths
+
+## Implementation Suggestions (Phased)
+
+### Phase 1: Resource container and providers
+
+- Add app-state resource container in `src/invproc/api.py` or a new module (for example `src/invproc/dependencies.py`)
+- Introduce `create_app()` (exporting `app = create_app()` for backward compatibility)
+- Implement lifespan initializer that constructs config and extract cache using config values
+- Add dependency functions such as `get_app_config(request)`, `get_extract_cache(request)`, and a Supabase client provider dependency
+- Update `/extract` to inject config/cache dependencies and remove direct `get_config()` call
+
+### Phase 2: Auth lifecycle refactor
+
+- Move Supabase client lifecycle responsibility out of module globals in `src/invproc/auth.py` into an app-scoped provider bound to startup config
+- Make `verify_supabase_jwt` depend on injected provider(s) rather than hidden module cache state
+- Preserve current API key auth fallback path (`src/invproc/auth.py:90`)
+- Add tests for missing Supabase config and token verification with the new dependency wiring
+
+### Phase 3: Test migration and cleanup
+
+- Introduce shared test fixtures (for example in `tests/conftest.py`) that build a fresh app via `create_app()` and provide `TestClient`
+- Replace global mutation/reset patterns in `tests/test_api.py` and `tests/test_error_paths.py` with explicit dependency overrides and fixture-owned resources
+- Convert tests that currently mutate env + call `reload_config()` mid-test to either rebuild app/client or override dependencies directly
+- Keep `limiter.reset()` reset behavior unless scope expands
+- Remove deprecated `reload_config()` usage from API tests once new fixtures are stable
+- Document the preferred testing pattern for dependency overrides in `tests/conftest.py` or contributor docs
+
+## Alternative Approaches Considered
+
+- Keep module globals and add more reset helpers:
+  - Rejected because it preserves hidden state coupling and fragile test behavior.
+- Full application factory rewrite immediately:
+  - Selected in a scoped form (`create_app()` for API composition) because it clarifies lifecycle ownership and test isolation without requiring a broader package-wide rewrite.
+- Per-request config object creation only (no app-state config/cache):
+  - Simpler for config, but not ideal for shared extraction cache lifecycle and test override clarity.
+
+## References & Research
+
+### Internal References
+
+- Global extraction cache import-time state: `src/invproc/api.py:46`
+- Per-request DI providers already in place (processors/validator): `src/invproc/api.py:67`, `src/invproc/api.py:72`, `src/invproc/api.py:77`
+- `/extract` direct `get_config()` call and module cache usage: `src/invproc/api.py:181`, `src/invproc/api.py:206`
+- Config singleton globals: `src/invproc/config.py:276`, `src/invproc/config.py:279`
+- Supabase client globals and lazy cache logic: `src/invproc/auth.py:14`, `src/invproc/auth.py:31`
+- Auth dependency wiring using `Depends(get_config)`: `src/invproc/auth.py:77`
+- API tests relying on imported globals + reload: `tests/test_api.py:9`, `tests/test_api.py:25`, `tests/test_api.py:26`, `tests/test_api.py:37`, `tests/test_api.py:38`
+- Error path tests relying on `reload_config()`: `tests/test_error_paths.py:15`, `tests/test_error_paths.py:26`, `tests/test_error_paths.py:31`
+- Config singleton/reload tests (likely to be adjusted or split API-vs-CLI semantics): `tests/test_config.py:49`, `tests/test_config.py:61`
+
+### Institutional Learnings
+
+- `docs/solutions/runtime-errors/global-state-thread-safety-race-conditions.md:17` documents prior FastAPI concurrency issues caused by global mutable state and recommends dependency injection/app state patterns
+- `docs/solutions/runtime-errors/global-state-thread-safety-race-conditions.md:71` captures the team’s chosen pattern: FastAPI dependency injection for request-scoped services
+- `docs/solutions/logic-errors/cache-disabled-extract-path-computes-cache-key-invoice-processing-api-20260226.md` highlights recent extract cache refactor regressions and reinforces targeted tests around cache-enabled vs disabled control flow
+
+### Canonical Project Policy References
+
+- CI workflow: `.github/workflows/ci.yml`
+- Quality gate policy: `docs/quality-gates.md`
+- PR template: `.github/pull_request_template.md`
+
+## PR / Validation Notes
+
+For the eventual PR, ensure policy alignment:
+
+- Include exactly one label: `change:refactor`
+- Include `### Refactor Regression Evidence` with concrete test evidence (no placeholders)
+- Keep required checks green: `lint`, `typecheck`, `tests`, `health-smoke`, `pr-policy`, `quality-gate-pr`

--- a/docs/solutions/best-practices/fastapi-app-factory-lifespan-di-resource-lifecycle-invoice-api-20260226.md
+++ b/docs/solutions/best-practices/fastapi-app-factory-lifespan-di-resource-lifecycle-invoice-api-20260226.md
@@ -1,0 +1,152 @@
+---
+module: Invoice Processing API
+date: 2026-02-26
+problem_type: best_practice
+component: development_workflow
+symptoms:
+  - "FastAPI API still used module-global lifecycle state for extraction cache, config singleton, and Supabase client cache despite partial DI usage"
+  - "API tests reset imported globals and called reload_config(), coupling behavior to import order and shared process state"
+  - "Refactoring resource ownership risked regressions unless startup/lifespan initialization and dependency override points were made explicit"
+root_cause: test_isolation
+resolution_type: code_fix
+severity: medium
+tags: [fastapi, dependency-injection, app-factory, lifespan, test-isolation, supabase, extract-cache]
+related:
+  - docs/solutions/runtime-errors/global-state-thread-safety-race-conditions.md
+  - docs/solutions/logic-errors/cache-disabled-extract-path-computes-cache-key-invoice-processing-api-20260226.md
+  - todos/050-complete-p2-auth-dependency-bypasses-api-provider-layer.md
+---
+
+# Troubleshooting: FastAPI Resource Lifecycle Refactor with `create_app()` + Lifespan + Dependency Overrides
+
+## Problem
+
+The invoice API had already adopted dependency injection for request-scoped processors, but it still relied on module-global lifecycle state for extraction cache, config singleton, and Supabase client caching. Tests worked by mutating environment variables, resetting imported globals, and calling `reload_config()`, which made resource behavior implicit and fragile.
+
+## Environment
+
+- Module: Invoice Processing API
+- Affected Component: FastAPI application composition, authentication dependency wiring, API test fixtures
+- Date: 2026-02-26
+
+## Symptoms
+
+- `src/invproc/api.py` created a module-global `extract_cache` at import time and `/extract` still called `get_config()` directly inside the route.
+- `src/invproc/config.py` and `src/invproc/auth.py` retained singleton/global caches (`_config_instance`, `_client`, `_client_url`, `_client_key`) for API paths.
+- API tests imported the shared `app` and `extract_cache`, then reset globals / called `reload_config()` to force behavior changes.
+- It was hard to reason about which resources were startup-owned vs request-owned and which overrides applied during tests.
+
+## What Didn't Work
+
+**Attempted Solution 1:** Keep module globals and add more reset helpers.
+- **Why it failed:** This preserved hidden coupling to import order and did not produce explicit dependency override points for tests.
+
+**Attempted Solution 2:** Only inject more route dependencies but leave app composition unchanged.
+- **Why it failed:** Long-lived resources (cache/config/auth client lifecycle) still needed a clear owner and startup timing, and tests would continue sharing a process-global app.
+
+**Direct solution:** Introduce a scoped `create_app()` composition path with lifespan-managed app resources and test fixtures that use explicit dependency overrides.
+
+## Solution
+
+Refactored the FastAPI app to use `create_app()` with lifespan-managed `app.state` resources, and migrated API tests to create fresh app instances with `app.dependency_overrides` instead of mutating module-global state.
+
+**Key code changes**:
+
+```python
+# src/invproc/api.py (new app composition pattern)
+@dataclass
+class AppResources:
+    config: InvoiceConfig
+    extract_cache: InMemoryExtractCache
+    supabase_client_provider: SupabaseClientProvider
+
+@asynccontextmanager
+async def app_lifespan(app: FastAPI):
+    app.state.invproc_resources = build_app_resources()
+    try:
+        yield
+    finally:
+        app.state.invproc_resources = None
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(..., lifespan=app_lifespan)
+    app.middleware("http")(add_observability_headers)
+    app.include_router(router)
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+    app.add_exception_handler(ContractError, contract_error_handler)
+    return app
+
+
+app = create_app()  # runtime compatibility
+```
+
+```python
+# /extract route now uses injected config/cache instead of direct get_config() call
+async def extract_invoice(
+    ...,
+    config: InvoiceConfig = Depends(get_app_config),
+    extract_cache: InMemoryExtractCache = Depends(get_extract_cache),
+    ...,
+):
+    result = await run_in_threadpool(..., config=config, cache=extract_cache)
+```
+
+```python
+# tests/conftest.py (explicit test-owned app + overrides)
+@pytest.fixture
+def api_test_app(...):
+    app = create_app()
+    app.dependency_overrides[get_app_config] = lambda: api_test_config
+    app.dependency_overrides[get_extract_cache] = lambda: api_test_extract_cache
+    app.dependency_overrides[get_supabase_client] = lambda: object()
+    yield app
+    app.dependency_overrides.clear()
+```
+
+**Config lifecycle support**:
+
+```python
+# src/invproc/config.py
+
+def build_config(*, validate: bool = True) -> InvoiceConfig:
+    config = InvoiceConfig()
+    if validate:
+        config.validate_config()
+    return config
+```
+
+**Commands run (verification):**
+
+```bash
+python -m ruff check src/ tests/
+python -m mypy src/
+python -m pytest -q
+```
+
+## Why This Works
+
+The underlying problem was not only thread safety; it was lifecycle ownership and test isolation. The codebase had a mixed model: some dependencies were request-scoped via FastAPI `Depends`, but other resources were created once at import time and mutated/reset in tests.
+
+The refactor works because it establishes a clear ownership model:
+
+1. **App-scoped resources** (config, extract cache, Supabase provider) are created in FastAPI lifespan and attached to `app.state`.
+2. **Request-scoped services** (PDF processor, LLM extractor, validator, import service) remain standard FastAPI dependencies built from injected config.
+3. **Tests use explicit overrides** on a fresh app instance, so resource behavior changes are local to that test app and no longer depend on mutating module globals.
+4. **Runtime compatibility is preserved** by exporting `app = create_app()` for existing imports and `uvicorn` entrypoints.
+
+This makes the dependency graph more explicit, reduces hidden state coupling, and aligns API behavior with FastAPI lifecycle conventions.
+
+## Prevention
+
+- Treat app resource ownership as a first-class design decision: define whether a dependency is app-scoped (lifespan) or request-scoped (`Depends`) before coding.
+- Avoid import-time creation of mutable API resources (caches, clients, config singletons) unless they are intentionally process-global and documented.
+- For API tests, prefer `create_app()` + `app.dependency_overrides` over environment mutation plus module-global resets.
+- When refactoring from globals to DI, verify both runtime behavior and test isolation behavior (e.g., cache toggles, auth wiring, per-test config changes).
+- Keep a single canonical composition path for middleware, routers, and lifecycle hooks to avoid dual initialization bugs.
+
+## Related Issues
+
+- See also: `docs/solutions/runtime-errors/global-state-thread-safety-race-conditions.md`
+- Related cache refactor regression lesson: `docs/solutions/logic-errors/cache-disabled-extract-path-computes-cache-key-invoice-processing-api-20260226.md`
+- Architecture review finding (resolved): `todos/050-complete-p2-auth-dependency-bypasses-api-provider-layer.md`

--- a/src/invproc/config.py
+++ b/src/invproc/config.py
@@ -276,13 +276,20 @@ class InvoiceConfig(BaseSettings):
 _config_instance = None
 
 
+def build_config(*, validate: bool = True) -> InvoiceConfig:
+    """Create a new configuration instance for an explicit lifecycle owner."""
+    config = InvoiceConfig()
+    if validate:
+        config.validate_config()
+        logger.info("Configuration validated successfully")
+    return config
+
+
 def get_config() -> InvoiceConfig:
     """Get or create global configuration instance."""
     global _config_instance
     if _config_instance is None:
-        _config_instance = InvoiceConfig()
-        _config_instance.validate_config()
-        logger.info("Configuration validated successfully")
+        _config_instance = build_config()
     return _config_instance
 
 
@@ -290,7 +297,7 @@ def get_config_unvalidated() -> InvoiceConfig:
     """Get or create global configuration instance without validation."""
     global _config_instance
     if _config_instance is None:
-        _config_instance = InvoiceConfig()
+        _config_instance = build_config(validate=False)
     return _config_instance
 
 

--- a/src/invproc/dependencies.py
+++ b/src/invproc/dependencies.py
@@ -1,0 +1,53 @@
+"""Shared FastAPI app resource container and provider dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+from fastapi import Depends, HTTPException, Request, status
+
+from invproc.config import InvoiceConfig
+from invproc.extract_cache import InMemoryExtractCache
+
+if TYPE_CHECKING:
+    from invproc.auth import SupabaseClientProvider
+
+
+@dataclass
+class AppResources:
+    """App-scoped resources initialized during FastAPI lifespan."""
+
+    config: InvoiceConfig
+    extract_cache: InMemoryExtractCache
+    supabase_client_provider: SupabaseClientProvider
+
+
+def get_app_resources(request: Request) -> AppResources:
+    """Return initialized app resources from state."""
+    resources = getattr(request.app.state, "invproc_resources", None)
+    if resources is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Application resources are not initialized",
+        )
+    return cast(AppResources, resources)
+
+
+def get_app_config(resources: AppResources = Depends(get_app_resources)) -> InvoiceConfig:
+    """Get app-scoped config instance."""
+    return resources.config
+
+
+def get_extract_cache(
+    resources: AppResources = Depends(get_app_resources),
+) -> InMemoryExtractCache:
+    """Get app-scoped extraction cache."""
+    return resources.extract_cache
+
+
+def get_supabase_client_provider(
+    resources: AppResources = Depends(get_app_resources),
+) -> "SupabaseClientProvider":
+    """Get app-scoped Supabase client provider."""
+    return resources.supabase_client_provider

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,17 @@
 """Shared test fixtures."""
 
 from collections.abc import Generator
+from typing import Any
 
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from invproc.api import create_app
+from invproc.auth import get_supabase_client
+from invproc.config import InvoiceConfig
+from invproc.dependencies import get_app_config, get_extract_cache
+from invproc.extract_cache import InMemoryExtractCache
 
 TEST_SUPABASE_TOKEN = "test-supabase-jwt"
 
@@ -28,3 +36,51 @@ def mock_supabase_auth(
 
     monkeypatch.setattr("invproc.auth.fetch_supabase_user", _fake_fetch_supabase_user)
     yield
+
+
+@pytest.fixture
+def api_test_config() -> InvoiceConfig:
+    """Provide a test-owned API config instance for dependency overrides."""
+    return InvoiceConfig(
+        _env_file=None,
+        mock=True,
+        max_pdf_size_mb=2,
+        extract_cache_enabled=False,
+        extract_cache_ttl_sec=3600,
+        extract_cache_max_entries=64,
+    )
+
+
+@pytest.fixture
+def api_test_extract_cache(api_test_config: InvoiceConfig) -> InMemoryExtractCache:
+    """Provide a test-owned extract cache for dependency overrides."""
+    return InMemoryExtractCache(
+        ttl_sec=api_test_config.extract_cache_ttl_sec,
+        max_entries=api_test_config.extract_cache_max_entries,
+    )
+
+
+@pytest.fixture
+def api_test_app(
+    monkeypatch: pytest.MonkeyPatch,
+    api_test_config: InvoiceConfig,
+    api_test_extract_cache: InMemoryExtractCache,
+) -> Generator[Any, None, None]:
+    """Create a fresh FastAPI app with explicit dependency overrides."""
+    monkeypatch.setenv("MOCK", "true")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "http://localhost:5173")
+    app = create_app()
+    app.dependency_overrides[get_app_config] = lambda: api_test_config
+    app.dependency_overrides[get_extract_cache] = lambda: api_test_extract_cache
+    app.dependency_overrides[get_supabase_client] = lambda: object()
+    try:
+        yield app
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def api_test_client(api_test_app: Any) -> Generator[TestClient, None, None]:
+    """Create a TestClient for the overridden API app."""
+    with TestClient(api_test_app) as client:
+        yield client

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 from fastapi.testclient import TestClient
 
 from invproc.cli import app
-from invproc.api import app as api_app
+from invproc.api import create_app
 from invproc.config import reload_config
 
 cli_runner = CliRunner()
@@ -23,7 +23,7 @@ def test_cli_api_consistency():
         os.environ["MOCK"] = "true"
         reload_config()
 
-        with TestClient(api_app) as api_client:
+        with TestClient(create_app()) as api_client:
             with open("test_invoices/invoice-test.pdf", "rb") as f:
                 api_response = api_client.post(
                     "/extract",

--- a/tests/test_error_paths.py
+++ b/tests/test_error_paths.py
@@ -9,7 +9,7 @@ from io import BytesIO
 
 from fastapi.testclient import TestClient
 
-from invproc.api import app, limiter
+from invproc.api import limiter
 from invproc.pdf_processor import PDFProcessor
 from invproc.llm_extractor import LLMExtractor
 from invproc.config import get_config, reload_config
@@ -44,10 +44,9 @@ def llm_extractor():
 
 
 @pytest.fixture
-def api_client():
+def api_client(api_test_client: TestClient):
     """Create API test client."""
-    with TestClient(app) as client:
-        yield client
+    yield api_test_client
 
 
 def test_malformed_pdf_not_pdf(pdf_processor, tmp_path):

--- a/tests/test_invoice_import_api.py
+++ b/tests/test_invoice_import_api.py
@@ -5,25 +5,18 @@ import os
 import pytest
 from fastapi.testclient import TestClient
 
-from invproc.api import app
-from invproc.config import reload_config
-
-
 @pytest.fixture(autouse=True)
 def setup_test_config() -> None:
     os.environ["ALLOWED_ORIGINS"] = "http://localhost:5173"
     os.environ["MOCK"] = "true"
-    reload_config()
     yield
     os.environ.pop("ALLOWED_ORIGINS", None)
     os.environ.pop("MOCK", None)
-    reload_config()
 
 
 @pytest.fixture
-def client() -> TestClient:
-    with TestClient(app) as c:
-        yield c
+def client(api_test_client: TestClient) -> TestClient:
+    yield api_test_client
 
 
 def test_preview_pricing_handles_missing_weight(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

This PR refactors FastAPI resource ownership in the Invoice Processing API to remove API-path reliance on module-global lifecycle state and make test setup explicit.

Before this change, the API mixed request-scoped dependency injection with module-global resources:
- extraction cache instantiated at import time in `api.py`
- config singleton lifecycle via `_config_instance` in `config.py`
- Supabase client singleton/cache state in `auth.py`
- API tests mutating globals and calling `reload_config()` to influence a shared imported app

That design made resource ownership implicit, coupled behavior to import order/process state, and made it harder to reason about startup vs request lifecycles.

This PR introduces a `create_app()` composition path with lifespan-managed app resources and migrates API tests to use explicit dependency overrides on fresh app instances.

## User Impact

For API consumers, endpoint behavior and status codes are preserved (`/health`, `/extract`, `/invoice/preview-pricing`).

For maintainers and contributors, the API is easier to test and reason about:
- app-scoped resources are initialized in one place (FastAPI lifespan)
- request-scoped services continue to use normal FastAPI DI
- tests no longer rely on mutating imported module globals for cache/config behavior

## Root Cause

The codebase had a mixed lifecycle model: some dependencies were request-scoped (`Depends`) while others were mutable module-global singletons. This caused hidden coupling between environment mutation, import timing, and test execution, especially in API tests using a shared imported app.

## What Changed

### FastAPI app composition and lifecycle

- Added `create_app()` in `src/invproc/api.py` and preserved runtime compatibility with `app = create_app()`
- Added FastAPI lifespan initialization for app-scoped resources attached to `app.state`
- Removed API request handling reliance on module-global extraction cache
- Updated `/extract` to inject config and extract cache via FastAPI dependencies instead of calling `get_config()` inside the route

### Shared dependency provider layer

- Added `src/invproc/dependencies.py` to host shared app resource container/provider dependencies:
  - `AppResources`
  - `get_app_resources`
  - `get_app_config`
  - `get_extract_cache`
  - `get_supabase_client_provider`
- Updated `src/invproc/auth.py` to use the shared provider layer (fixing an architectural review finding about auth bypassing the API provider abstraction)

### Config and auth lifecycle improvements

- Added `build_config()` in `src/invproc/config.py` for explicit lifecycle-owned config construction while preserving existing singleton helpers for CLI/backward compatibility
- Replaced auth module-global Supabase client cache state with app-scoped `SupabaseClientProvider`

### Test refactor

- Added canonical API test fixtures in `tests/conftest.py` using `create_app()` and `app.dependency_overrides`
- Migrated affected API tests away from imported global cache/config mutation patterns
- Updated API E2E test to instantiate a fresh app with `create_app()`

## Refactor Notes (Cause and Effect)

This is a lifecycle/DI refactor, not a feature change. The main effect is improved architectural clarity and test isolation:
- fewer hidden globals in API request paths
- explicit app-scoped vs request-scoped dependency boundaries
- more reliable per-test behavior for cache/config/auth wiring

A follow-up architecture review finding (auth provider path bypassing shared providers) was fixed in this branch by introducing the shared dependency module and updating auth to consume it.

## Testing

### Refactor Regression Evidence

Validated locally with the required quality gates:

- `python -m ruff check src/ tests/`
- `python -m mypy src/`
- `python -m pytest -q`

Results:
- `ruff` passed
- `mypy` passed (22 source files checked)
- `pytest` passed (`109 passed`)
- coverage gate passed (`82.03%`, fail-under `80%`)

Additional targeted validation during implementation:
- `python -m pytest -q --no-cov tests/test_api.py tests/test_error_paths.py tests/test_invoice_import_api.py tests/test_e2e.py`
- targeted `ruff`/`mypy` checks after addressing the auth provider-layer review finding

## Documentation

Included:
- implementation plan document in `docs/plans/2026-02-26-refactor-fastapi-resource-lifecycle-plan.md`
- compounding solution doc in `docs/solutions/best-practices/fastapi-app-factory-lifespan-di-resource-lifecycle-invoice-api-20260226.md`

## Labels / Policy

This PR is a refactor and should use exactly one change-type label:
- `change:refactor`
