### PR TITLE
[codex] Add project status guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,8 @@ Apply exactly one label to this PR:
 - [ ] `ruff check src/ tests/` passes locally
 - [ ] Coverage is at least 80%
 - [ ] `/health` smoke check works
+- [ ] Updated `docs/project-status.md` if current priorities, active work, recent completions, or next-up sequencing changed
+- [ ] Updated affected `docs/plans/` status/frontmatter if this PR completed, advanced, superseded, or reprioritized tracked work
 
 ### Feature Test Evidence
 Provide concrete evidence for feature changes (tests added/updated, commands run, behavior proven).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,18 @@ Repository-specific instructions for coding agents working in this project.
   - `### Deploy Verification Plan`
 - Avoid placeholder evidence (`TBD`, `TODO`, `N/A`).
 
+## Project Status Hygiene (Required)
+- `docs/project-status.md` is the repo control-tower view for:
+  - current priorities
+  - active work
+  - recently completed work
+  - next up
+- If a PR starts, completes, supersedes, or reprioritizes tracked work, update both:
+  - the controlling file under `docs/plans/`
+  - `docs/project-status.md`
+- Do not overload `README.md` as the roadmap and do not treat `docs/solutions/` as the priority queue.
+- If the work does not affect current sequencing or tracked work state, note that explicitly in the PR rather than updating `docs/project-status.md` unnecessarily.
+
 ## Required Branch Protection Checks (`main`)
 - `lint`
 - `typecheck`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,15 @@ Apply throughout all interactions: plans, explanations, code reviews, feedback. 
 - CI workflow path: `.github/workflows/ci.yml`
 - Policy reference: `docs/quality-gates.md`
 
+## Project Status Hygiene
+
+- Treat [`docs/project-status.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/project-status.md) as the repo control-tower view.
+- If a change starts, completes, supersedes, or reprioritizes tracked work, update:
+  - the controlling file in `docs/plans/`
+  - [`docs/project-status.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/project-status.md)
+- Do not use `README.md` as the roadmap and do not treat `docs/solutions/` as the priority queue.
+- If no project-control update is needed, state that explicitly when packaging the PR.
+
 ---
 
 ## Commands
@@ -123,7 +132,7 @@ Validation runs twice. First, Pydantic's `model_validator` on `Product` runs dur
 
 ## Key details to keep in mind
 
-- The `README.md` contains an older FastAPI blueprint (not the current CLI). The actual running code is entirely under `src/invproc/`.
+- `README.md` now contains operator-facing usage plus current backend RAG workflow notes, but it is not the roadmap. Use `docs/project-status.md` for current priorities and `docs/plans/` for implementation control.
 - `tests/` is active and enforces project coverage >= 80% via pytest config.
 - The system prompt in `llm_extractor.py:_get_system_prompt()` is METRO Cash & Carry-specific (Romanian column headers like "Cant.", "Pret unitar", "Valoare incl.TVA"). Generalizing to other invoice formats will require prompt changes.
 - `response_format={"type": "json_object"}` is used instead of Pydantic-native structured output (`client.chat.completions.parse`). The JSON is manually parsed and fed to the Pydantic model.

--- a/docs/ideation/2026-03-29-project-status-priority-clarity-ideation.md
+++ b/docs/ideation/2026-03-29-project-status-priority-clarity-ideation.md
@@ -1,0 +1,101 @@
+---
+date: 2026-03-29
+topic: project-status-priority-clarity
+focus: roadmap clarity, current status, priorities, next work
+---
+
+# Ideation: Project Status and Priority Clarity
+
+## Codebase Context
+
+This repository already has substantial planning and historical documentation, but it is distributed across several layers with different purposes:
+
+- [`README.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/README.md) gives operator and developer usage guidance
+- [`docs/contracts/`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/contracts) locks feature boundaries and runtime semantics
+- [`docs/plans/`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans) contains feature plans, some completed and some still marked active
+- [`docs/solutions/`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/solutions) captures solved problems and architectural learnings
+- [`docs/ideation/`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/ideation) stores idea-generation artifacts
+
+Grounded signals from the current repo state:
+
+- There is no single roadmap or status-control document that answers “what is done, what is active, what is next, and why”.
+- Current next-work reasoning requires reading multiple plans, contract notes, and recent solution docs, then reconciling them manually.
+- At least two plans are still marked `active` today, including the compare-first RAG eval harness and the hybrid sync/async extract contract.
+- The main RAG phase plan is marked `completed`, but still contains an in-progress Phase 5 section, which creates ambiguity about whether the feature track is done or still open.
+- Recent PM/doc follow-up was necessary just to align the README, contract, and March 28 plan status with what was actually shipped.
+
+Relevant institutional learnings:
+
+- Contract and CLI/API parity drift has already caused repeated confusion in the RAG subsystem.
+- Several workflow learnings in [`docs/solutions/workflow-issues/`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/solutions/workflow-issues) point to process drift, missing verification steps, and stale context as recurring problems.
+- The repo has strong quality gates for code changes, but no equally strong workflow for keeping project-control docs synchronized after merges.
+
+## Ranked Ideas
+
+### 1. Add a single `docs/project-status.md` as the canonical “control tower”
+**Description:** Create one manually maintained status document that answers only four things: `Current priorities`, `Active work`, `Recently completed`, and `Next up`. It should link out to plans and contracts instead of duplicating them. The document becomes the first place to check before asking “what next?” or opening a new plan.
+**Rationale:** This is the cleanest fix for the exact pain you hit. It does not fight the existing docs structure; it adds one control layer above it. It also solves the repo’s current gap more directly than trying to force README or plans to act like a roadmap.
+**Downsides:** It adds one more file that can go stale unless there is a maintenance rule tied to merges.
+**Confidence:** 96%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 2. Add a strict plan lifecycle workflow with required status transitions
+**Description:** Define and enforce a small lifecycle for plan docs: `planned -> active -> completed -> superseded`. Require every merge that finishes a scoped plan to update that plan’s frontmatter and acceptance checklist, and require any follow-up plan to explicitly reference which earlier plan it continues or supersedes.
+**Rationale:** The current ambiguity is partly structural: some plans are “completed” while containing open in-progress sub-phases, and some active plans may already be partly shipped. Tightening lifecycle semantics would make the planning layer much easier to trust.
+**Downsides:** This fixes consistency, but by itself it still leaves the user scanning many files to understand current priorities.
+**Confidence:** 93%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 3. Generate a machine-readable project inventory from plan frontmatter
+**Description:** Standardize plan frontmatter enough to support a small script that lists all plans by `status`, `type`, `date`, and `topic`, then generates a compact dashboard or markdown summary. This could also flag contradictions such as “completed file with unchecked acceptance criteria” or multiple active plans in the same feature lane.
+**Rationale:** The repo already encodes most of the needed information in docs; the problem is retrieval and consistency. A generated inventory would turn scattered plan metadata into a usable program view.
+**Downsides:** It requires frontmatter normalization across older plans before the output becomes trustworthy, so it is not the fastest first fix.
+**Confidence:** 88%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 4. Split project control into “Product Now/Next/Later” and “Engineering Workstreams”
+**Description:** Maintain two lightweight project-facing docs instead of one overloaded roadmap:
+- a product-facing `Now / Next / Later` summary
+- an engineering workstream map that lists active tracks like `RAG quality`, `extract async`, `quality-gate policy`, `import flow`
+
+Each workstream would point to its controlling plan and recent solution docs.
+**Rationale:** The repo currently mixes delivery sequencing with architecture history. Separating product priority from technical track state makes it easier to answer both “what should we work on next?” and “what has already been done on this subsystem?” without overloading one file.
+**Downsides:** More structure than a single status doc, so it risks becoming ceremony if not kept concise.
+**Confidence:** 85%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 5. Add a merge checklist item for project-status updates
+**Description:** Extend the repo workflow so feature/refactor PRs must answer: “Does this change require updates to project control docs?” If yes, the PR must update the control doc, affected plan statuses, and any contract/README drift. This can live in the PR template or AGENTS guidance.
+**Rationale:** The repo already enforces code quality and PR evidence strongly. This idea adds a small governance step so roadmap/status clarity becomes part of done-ness, not a later cleanup.
+**Downsides:** It improves maintenance but does not define the status surface itself; it is strongest only in combination with Idea 1 or 4.
+**Confidence:** 91%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 6. Create a “current priorities” CLI command or generated note
+**Description:** Add a simple command or script such as `python scripts/project_status.py` that prints the active plans, latest completed work, and recommended next step based on a curated file or plan metadata. This can support terminal workflows without forcing people to scan markdown manually.
+**Rationale:** The repo is CLI-heavy, and a command-line status view matches how work is already being done. It also lowers the friction of checking priorities before starting new changes.
+**Downsides:** If the underlying source of truth is fuzzy, the command only automates confusion. This should come after the control model is clarified.
+**Confidence:** 80%
+**Complexity:** Medium
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Put the full roadmap directly into `README.md` | Too overloaded; README should stay operator/developer-oriented, not become the project control surface. |
+| 2 | Keep using plans only and just read them more carefully | This is the current failure mode; the repo already proves that scattered plans are not enough for quick status clarity. |
+| 3 | Use GitHub Projects as the only source of truth | Not grounded in the current repo workflow; the codebase already uses durable markdown docs as the planning record. |
+| 4 | Replace all existing docs with one big master roadmap | Too destructive and too expensive relative to the problem. The current docs should be organized, not flattened. |
+| 5 | Solve it purely with automation first | Premature. Without clearer status semantics and ownership, automation will just generate low-trust output. |
+| 6 | Track everything only through solution docs | Solution docs explain what happened and why; they are historical and architectural, not a priority queue. |
+| 7 | Open more issue tickets for every next-step question | Adds fragmentation instead of reducing it. The missing layer is synthesis, not more containers. |
+
+## Session Log
+
+- 2026-03-29: Initial ideation — 13 candidate directions considered, 6 survivors kept.

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -1,0 +1,128 @@
+# Project Status
+
+Last updated: 2026-03-29
+
+This is the control-tower view for the repo.
+
+Use this file to answer:
+- what is currently active
+- what was completed recently
+- what should happen next
+
+Canonical detail still lives in:
+- `docs/plans/` for implementation plans
+- `docs/contracts/` for locked behavior and ownership boundaries
+- `docs/solutions/` for solved problems and learnings
+
+## Current Priorities
+
+1. Finish RAG Phase 5 validation and quality tuning.
+2. Decide and implement the hybrid sync/async extraction path for slow invoices.
+3. Keep project-control docs aligned with shipped work so priority questions do not require manual reconciliation across many files.
+
+## Active Work
+
+### 1. RAG eval harness and retrieval-quality validation
+
+Status: Active
+
+Why it matters:
+- The backend RAG pipeline is already live and materially improved.
+- Phase 5 is still open at the validation/tuning layer.
+- Broad category-intent retrieval is still weaker than the tea-specific fixes that just shipped.
+
+Canonical files:
+- [docs/plans/2026-03-20-001-feat-rag-whatsapp-catalog-sync-plan.md](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans/2026-03-20-001-feat-rag-whatsapp-catalog-sync-plan.md)
+- [docs/plans/2026-03-27-001-feat-rag-eval-harness-regression-reporting-plan.md](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans/2026-03-27-001-feat-rag-eval-harness-regression-reporting-plan.md)
+- [docs/contracts/2026-03-20-rag-catalog-sync-contract.md](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/contracts/2026-03-20-rag-catalog-sync-contract.md)
+
+Current gaps:
+- cross-category eval coverage is still weak and partly ad hoc
+- some Phase 5 acceptance items in the main RAG plan are still unchecked
+- generic category queries such as `alcool`, `legume`, `cereale`, `bauturi` still need better retrieval quality
+
+Recommended next step:
+- build and save a cross-category eval fixture/baseline, then tune retrieval against it
+
+### 2. Hybrid sync/async extraction contract
+
+Status: Active
+
+Why it matters:
+- representative invoices still take too long for a clean synchronous frontend experience
+- this is the clearest next major product capability after the recent RAG improvements
+
+Canonical file:
+- [docs/plans/2026-03-27-002-feat-hybrid-extract-sync-async-plan.md](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans/2026-03-27-002-feat-hybrid-extract-sync-async-plan.md)
+
+Current gap:
+- the plan exists, but the feature has not been implemented yet
+
+Recommended next step:
+- decide whether this becomes the next major feature immediately after RAG Phase 5 tightening, or in parallel if the RAG work is kept narrow
+
+## Recently Completed
+
+### March 28 RAG retrieval follow-up
+
+Completed:
+- embedding text enrichment for tea-family and other safe inferred cases
+- canonical category backfill for safe null-category products
+- latest synced embedding selection per product during retrieval
+- API naming alignment around `match_threshold`
+
+Canonical files:
+- [docs/plans/2026-03-28-001-feat-rag-embedding-text-enrichment-plan.md](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans/2026-03-28-001-feat-rag-embedding-text-enrichment-plan.md)
+- [docs/plans/2026-03-28-002-feat-rag-category-backfill-and-latest-sync-selection-plan.md](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans/2026-03-28-002-feat-rag-category-backfill-and-latest-sync-selection-plan.md)
+- [docs/solutions/architecture-issues/rag-embedding-enrichment-category-backfill-latest-sync-selection-20260328.md](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/solutions/architecture-issues/rag-embedding-enrichment-category-backfill-latest-sync-selection-20260328.md)
+
+User-visible outcome:
+- `ceai de fructe` now maps back to tea products instead of fruit-snack distractors in the target case
+
+### March 29 PM/documentation alignment
+
+Completed:
+- README updated for current backend RAG workflow
+- RAG contract updated to reflect current embedding text and retrieval semantics
+- March 28 plans marked completed
+
+Canonical files:
+- [README.md](/Users/vladislavcaraseli/Documents/InvoiceProcessing/README.md)
+- [docs/contracts/2026-03-20-rag-catalog-sync-contract.md](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/contracts/2026-03-20-rag-catalog-sync-contract.md)
+
+## Next Up
+
+### Recommended immediate next task
+
+Create a proper cross-category RAG benchmark.
+
+Scope:
+- add 30-50 category-level and broad-intent retrieval cases
+- save a trustworthy baseline
+- use it to evaluate remaining Phase 5 RAG tuning work
+
+Why first:
+- it closes the current “what exactly is still weak?” gap with evidence
+- it aligns with the active RAG eval-harness plan
+- it reduces the chance of tuning retrieval based only on ad hoc manual checks
+
+### Recommended next major feature after that
+
+Implement the hybrid sync/async extraction contract.
+
+Why:
+- it is the clearest open product feature in the active plan set
+- it addresses a user-facing latency problem rather than another internal quality refinement
+
+## Decision Notes
+
+- Do not treat `README.md` as the roadmap. It should remain operator/developer-facing.
+- Do not treat `docs/solutions/` as the priority queue. It is historical memory.
+- Use this file as the first place to check before starting new planning work.
+- When a plan is completed or priorities change, update this file in the same PR if the change affects current work sequencing.
+
+## Quick Rules
+
+- If work is in progress: the controlling plan should be `status: active` and listed under `Active Work`.
+- If work is done: the plan should be `status: completed` and moved to `Recently Completed` if it matters to current context.
+- If someone asks “what next?”: answer from this file first, then follow links into the controlling plan.

--- a/docs/solutions/workflow-issues/project-status-control-tower-and-plan-hygiene-20260329.md
+++ b/docs/solutions/workflow-issues/project-status-control-tower-and-plan-hygiene-20260329.md
@@ -1,0 +1,142 @@
+---
+title: "Scattered plans and docs hid what was active, done, and next"
+category: "workflow-issues"
+date: "2026-03-29"
+tags: ["workflow", "project-status", "planning", "documentation", "roadmap", "pr-hygiene"]
+components: ["docs/project-status.md", "AGENTS.md", ".github/pull_request_template.md", "CLAUDE.md", "/Users/vladislavcaraseli/.codex/skills/yeet/SKILL.md", "docs/plans/"]
+symptoms:
+  - "Answering 'what should we work on next?' required manually reconciling README, plans, contracts, and recent solution docs"
+  - "Completed work and active work were both visible in the repo, but there was no single control surface for current priorities"
+  - "A completed top-level plan could still contain an in-progress sub-phase, which made feature-track status ambiguous"
+---
+
+## Problem
+
+The repo had plenty of documentation, but not enough project control.
+
+By late March 2026, the planning and knowledge layers were all individually useful:
+
+- [`README.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/README.md) for operator and developer usage
+- [`docs/plans/`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans) for implementation intent
+- [`docs/contracts/`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/contracts) for behavior boundaries
+- [`docs/solutions/`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/solutions) for solved-problem memory
+
+But there was no single file that answered the operational PM question:
+
+> what is active, what was just completed, and what should happen next?
+
+That forced manual reconciliation across multiple documents every time someone asked for priorities.
+
+## Root Cause
+
+This was not a lack-of-docs problem. It was a missing-control-surface problem.
+
+- The repo had historical memory and implementation plans, but no canonical status dashboard above them.
+- Plan status semantics were not strong enough on their own to answer priority questions quickly.
+- Merge/package workflows enforced code quality and PR evidence, but they did not enforce project-status hygiene.
+- `README.md` risked becoming a de facto roadmap, while `docs/solutions/` risked being read like an active priority queue even though neither file set was designed for that role.
+
+## Investigation Steps
+
+- Reviewed the current planning layer and found at least two active plans that still represented meaningful future work:
+  - [`docs/plans/2026-03-27-001-feat-rag-eval-harness-regression-reporting-plan.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans/2026-03-27-001-feat-rag-eval-harness-regression-reporting-plan.md)
+  - [`docs/plans/2026-03-27-002-feat-hybrid-extract-sync-async-plan.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans/2026-03-27-002-feat-hybrid-extract-sync-async-plan.md)
+- Re-read the main RAG phase plan and confirmed that the file was marked completed overall while still containing an in-progress Phase 5 retrieval-quality section:
+  - [`docs/plans/2026-03-20-001-feat-rag-whatsapp-catalog-sync-plan.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/plans/2026-03-20-001-feat-rag-whatsapp-catalog-sync-plan.md)
+- Verified that recent March 28 work had required explicit PM/documentation cleanup after implementation, which was a strong signal that the repo needed a durable status-maintenance rule rather than another one-off refresh.
+- Compared this workflow problem to earlier repo learnings and found strong precedent:
+  - [`docs/solutions/workflow-issues/stale-frontend-branch-masked-pricing-fixes-development-workflow-20260211.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/solutions/workflow-issues/stale-frontend-branch-masked-pricing-fixes-development-workflow-20260211.md)
+  - [`docs/solutions/workflow-issues/strict-quality-gates-for-prs-development-workflow-20260217.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/solutions/workflow-issues/strict-quality-gates-for-prs-development-workflow-20260217.md)
+
+## Fix
+
+### 1. Add one control-tower file
+
+Created [`docs/project-status.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/project-status.md) as the canonical high-level project status view.
+
+It intentionally answers only:
+
+- current priorities
+- active work
+- recently completed work
+- next up
+
+It links outward to controlling plans and contracts instead of duplicating their detail.
+
+### 2. Define repo-level project-status hygiene
+
+Updated [`AGENTS.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/AGENTS.md) to define when project-control docs must be updated:
+
+- when a PR starts tracked work
+- when a PR completes tracked work
+- when a PR supersedes tracked work
+- when a PR changes work sequencing or priorities
+
+The rule is to update both:
+
+- the controlling file in `docs/plans/`
+- [`docs/project-status.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/project-status.md)
+
+### 3. Add a PR-time reminder
+
+Updated [`.github/pull_request_template.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/.github/pull_request_template.md) with checklist items for:
+
+- project-status updates
+- plan-status/frontmatter updates
+
+This made project-control maintenance part of merge packaging instead of a best-effort follow-up.
+
+### 4. Align agent packaging behavior
+
+Updated [`CLAUDE.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/CLAUDE.md) and the local [`yeet` skill](/Users/vladislavcaraseli/.codex/skills/yeet/SKILL.md) so the same rule is visible in both agent instruction surfaces.
+
+The `yeet` workflow now checks for project-control impact before staging and PR creation. If the diff appears to change tracked work state or sequencing, it must verify:
+
+- `docs/project-status.md`
+- the controlling `docs/plans/` file
+
+or explicitly note that no project-control update was needed.
+
+## Result
+
+The repo now has a layered documentation model with a clear control boundary:
+
+- `README.md` remains operator/developer-facing
+- `docs/plans/` remain the implementation record
+- `docs/contracts/` remain the behavior record
+- `docs/solutions/` remain the historical learning record
+- `docs/project-status.md` is now the first place to answer “what now, what next, and why”
+
+That change does not automate prioritization. It does something more important first: it makes the status source of truth explicit and gives merge workflows a way to keep it current.
+
+## Verification
+
+The fix was verified by inspecting the final repo surfaces after the changes:
+
+- [`docs/project-status.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/project-status.md) existed and contained current priorities, active work, recent completions, and next-step guidance grounded in existing plans
+- [`AGENTS.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/AGENTS.md) contained explicit project-status hygiene rules
+- [`.github/pull_request_template.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/.github/pull_request_template.md) contained checklist items for status and plan updates
+- [`CLAUDE.md`](/Users/vladislavcaraseli/Documents/InvoiceProcessing/CLAUDE.md) reflected the same policy
+- the local [`yeet` skill](/Users/vladislavcaraseli/.codex/skills/yeet/SKILL.md) was updated to enforce the rule during PR packaging
+
+## Prevention
+
+- Keep `docs/project-status.md` narrow. If it grows into another long narrative doc, people will stop using it.
+- Never use `README.md` as the roadmap. It will drift because its job is usage, not prioritization.
+- Never use `docs/solutions/` as the active priority queue. It records what was learned, not what should happen next.
+- Any PR that changes tracked work state should update the controlling plan and the control-tower file in the same change set.
+- Automation should come after status semantics are clear, not before. A script can later validate active/completed mismatches, but only after the human-owned status model is stable.
+
+Useful follow-up checks:
+
+- compare active plans in `docs/plans/` against `docs/project-status.md`
+- flag completed plans that still have unchecked acceptance items
+- flag project-status entries that point to plans no longer marked active
+
+## See Also
+
+- [Strict quality gates for PRs and development workflow](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/solutions/workflow-issues/strict-quality-gates-for-prs-development-workflow-20260217.md)
+- [Stale frontend branch masked pricing fixes and created false regression signals](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/solutions/workflow-issues/stale-frontend-branch-masked-pricing-fixes-development-workflow-20260211.md)
+- [Feature propagation gaps across SQL, dataclasses, and CLI/API parity](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/solutions/integration-issues/feature-propagation-gaps-sql-param-collision-dataclass-cli-parity.md)
+- [RAG catalog sync contract](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/contracts/2026-03-20-rag-catalog-sync-contract.md)
+- [Project-status clarity ideation](/Users/vladislavcaraseli/Documents/InvoiceProcessing/docs/ideation/2026-03-29-project-status-priority-clarity-ideation.md)


### PR DESCRIPTION
## Summary
This PR adds a lightweight project-control layer so the repo can answer "what is active, what is done, and what should happen next" without manually reconciling README usage notes, plan files, contracts, and solution docs.

The change adds `docs/project-status.md` as the canonical control-tower view, documents the rationale in a workflow solution note, and adds maintenance guardrails in the repo instructions and PR packaging workflow.

## Root Cause
The repository already had a healthy amount of documentation, but those docs served different jobs:

- `README.md` for usage
- `docs/plans/` for implementation intent
- `docs/contracts/` for behavior boundaries
- `docs/solutions/` for historical learning

What was missing was a dedicated status-control surface. That made "what next?" a manual reconciliation task instead of a quick lookup. The workflow also had no explicit rule requiring project-status updates when tracked work state changed.

## What Changed
- add `docs/project-status.md` as the repo control-tower doc
- add a workflow solution doc capturing the problem, fix, and prevention rule
- update `AGENTS.md` with project-status hygiene requirements
- update `CLAUDE.md` with the same control-tower guidance
- update `.github/pull_request_template.md` with checklist items for project-status and plan-status updates
- update the local `yeet` skill so PR packaging checks for project-control impact before staging

No existing tracked feature plan was completed or reprioritized by this PR, so no `docs/plans/` state transition was needed beyond documenting the new hygiene rule.

### Refactor Regression Evidence
- `python -m ruff check src/ tests/`
- `python -m mypy src/`
- `python -m pytest -q`
- scope check: diff limited to repo instructions, project-control docs, and documentation artifacts

## Risks
This change adds process, so the main risk is over-maintenance if `docs/project-status.md` grows beyond a concise control surface. The mitigation is to keep that file intentionally narrow and link outward to plans instead of duplicating them.
